### PR TITLE
add missing dependency 'gbaimg'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Joshua Karns"]
 
 [dependencies]
-
+"gbaimg" = {path = "gbaimg", version = "*"}
 [lib]
 name = "gbalib"
 path = "src/lib.rs"


### PR DESCRIPTION
There was a reference to gbaimg missing inside the Cargo.toml

```
[fence@fake-arch stdgba]$ make build
xargo build --target gba --release
   Compiling core v0.0.0 (file:///home/fence/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libcore)
    Finished release [optimized] target(s) in 25.50 secs
   Compiling gbalib v0.1.0 (file:///home/fence/code/stdgba)
error[E0463]: can't find crate for `gbaimg`
 --> src/lib.rs:6:1
  |
6 | pub extern crate gbaimg;
  | ^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate

```