### PR TITLE
Fix makefile formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
+.PHONY: build
 build:
-    xargo build --target gba --release
+	xargo build --target gba --release


### PR DESCRIPTION
Makefiles need to be indented with tabs to work.
And while I was at it, I also added a `PHONY` directive, which tells make that a build target is not a file. (E.g. if we had a file called `build`, it would not run the compile command and do nothing, because the file already exists 😉)